### PR TITLE
Move `neostandard` to `devDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "marked": "^13.0.3",
     "minimatch": "^10.0.1",
     "mkcert": "^3.2.0",
+    "neostandard": "^0.11.1"
     "open": "^10.1.0",
     "path2d": "^0.2.1",
     "prismjs": "^1.29.0",
@@ -49,8 +50,5 @@
     "stylelint-config-standard": "^36.0.1",
     "typescript": "^5.5.4",
     "wonton": "^2.3.0"
-  },
-  "dependencies": {
-    "neostandard": "^0.11.1"
   }
 }


### PR DESCRIPTION
When researching repos that would be good candidates for canary tests (https://github.com/neostandard/neostandard/pull/85) I noticed that it had accidentally been added as a dependency when moved to from `eslint-config-standard`

Would you be interested in being added to the canary tests?